### PR TITLE
Controllo del download di Sonarr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ENV PIP_ROOT_USER_ACTION ignore
 # USER dockeruser
 ENV USER_NAME dockeruser
 
-ENV VERSION "1.8.3"
+ENV VERSION "1.8.4"
 
 EXPOSE 5000
 

--- a/config/other/exceptions.py
+++ b/config/other/exceptions.py
@@ -6,5 +6,6 @@ class TableFormattingError(Exception):
 		super().__init__(self.message)
 
 class UnauthorizedSonarr(Exception):
+	"""Errore accesso a Sonarr."""
 	def __init__(self, message):
 		super().__init__(message)

--- a/config/other/texts.py
+++ b/config/other/texts.py
@@ -64,6 +64,7 @@ EPISODE_RENAME_DONE_LOG = "✔️ Episodio rinominato."
 EPISODE_RENAME_ERROR_LOG = "⚠️ NON è stato possibile rinominare l'episodio."
 SEND_CONNECTION_MESSAGE_LOG = "✉️ Inviando il messaggio tramite 𝗰𝗼𝗻𝗻𝗲𝗰𝘁𝗶𝗼𝗻𝘀."
 NO_EPISODES = "Non c'è nessun episodio da cercare."
+EPISODE_ALREADY_IN_DOWNLOADING_LOG = "🔒 L'episodio è già in download su Sonarr."
 
 AUTOMATIC_LINK_SEARCH_LOG = "⚠️ Ricerca automatica link di AnimeWorld per la 𝘴𝘵𝘢𝘨𝘪𝘰𝘯𝘦 {season} della 𝘴𝘦𝘳𝘪𝘦 '{anime}'."
 ABSOLUTE_AUTOMATIC_LINK_SEARCH_ERROR_LOG = "⛔ La ricerca automatica link di AnimeWorld è incompatibile con le serie ad ordinamento assoluto."

--- a/config/utility/functions.py
+++ b/config/utility/functions.py
@@ -7,6 +7,7 @@ import json
 import shutil
 from datetime import datetime
 from typing import Dict, List
+import time
 
 
 from app import socketio
@@ -14,6 +15,7 @@ from app import socketio
 from .table import Table
 from .logger import logger, message
 from .settings import Settings
+from . import sonarr
 import other.texts as txt
 from other.exceptions import TableFormattingError
 
@@ -279,3 +281,19 @@ def downloadProgress(d):
 		downloadProgress.step = datetime.timestamp(datetime.now())
 
 downloadProgress.step = datetime.timestamp(datetime.now())
+
+def downloadControl(args: Dict[str,str], opt: List[str]):
+	"""
+	Controlla il download del file.
+	`opt`: opzioni da modificare.
+	`args`: {
+		active: bool
+		epId: int
+	}
+	"""
+
+	while args["active"]:
+		if sonarr.inQueue(args["epId"]):
+			opt.append('abort')
+			return
+		time.sleep(60)

--- a/config/utility/sonarr.py
+++ b/config/utility/sonarr.py
@@ -7,6 +7,9 @@ from other.constants import SONARR_URL, API_KEY
 import other.texts as txt
 from other.exceptions import UnauthorizedSonarr
 
+# https://sonarr.tv/docs/api/
+# https://github.com/Sonarr/Sonarr/wiki/API (Legacy)
+
 def getMissingEpisodes() -> List[Dict]:
 	"""
 	Ottiene tutte le informazioni riguardante gli episodi mancanti da Sonarr.
@@ -151,7 +154,7 @@ def renameEpisode(seriesId:int, epFileId:int):
 	}
 	requests.post(url, json=data)
 
-def getEpisodeFileID(epId): # Converte l'epId in epFileId
+def getEpisodeFileID(epId:int) -> int: # Converte l'epId in epFileId
 	"""
 	Trova l'ID del file (`epFileId`) partendo dall'ID dell'episodio (`epId`).
 
@@ -161,3 +164,11 @@ def getEpisodeFileID(epId): # Converte l'epId in epFileId
 	"""
 	data = getEpisode(epId)
 	return data["episodeFile"]["id"]
+
+def inQueue(epId:int) -> bool:
+	"""
+	Controlla se l'episodio è in download da Sonarr.
+	"""
+	endpoint = "queue"
+	url = "{}/api/{}?apikey={}".format(SONARR_URL, endpoint, API_KEY)
+	return epId in [x["episode"]["id"] for x in requests.get(url).json()]

--- a/documentation/examples/json/table.json
+++ b/documentation/examples/json/table.json
@@ -436,6 +436,15 @@
         "title": "Redo of Healer"
     },
     {
+        "title": "Reincarnated as a Sword",
+        "seasons": {
+            "1": [
+                "https://www.animeworld.tv/play/tensei-shitara-ken-deshita.ABj8v"
+            ]
+        },
+        "absolute": false
+    },
+    {
         "absolute": false,
         "seasons": {
             "1": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-animeworld>=1.4.18
+animeworld>=1.4.20
 schedule>=0.6.0
 flask
 flask_socketio


### PR DESCRIPTION
- Aggiunto un controllo che, se l'episodio è in download dal programma ([Sonarr-AnimeDownloader](https://github.com/MainKronos/Sonarr-AnimeDownloader)) e è anche in download su Sonarr, allora abortisce quello del programma in favore di quello su Sonarr.

Un log di esempio:
```
...
╭───────────────────────────────────「09 Oct 2022 19:08:42」───────────────────────────────────╮

─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ 

🔎 Ricerca anime 'Summer Time Rendering' stagione 1.
🔎 Ricerca episodio 1.

⚙️ Verifica se l'episodio 𝐒1𝐄1 è disponibile.
✔️ L'episodio è disponibile.
⏳ Download episodio 𝐒1𝐄1.
🔒 L'episodio è già in download su Sonarr.

─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
...
```