### PR TITLE
fix: rinominare thetvdb_id in tvdb_id

### DIFF
--- a/src/components/backend/connection/ExternalDB.py
+++ b/src/components/backend/connection/ExternalDB.py
@@ -53,10 +53,10 @@ class ExternalDB:
 		# Ottengo un elenco di ID di MyAnimeList che fanno match
 		mal_ids = []
 		for info in self._data:
-			if "thetvdb_id" not in info: continue
+			if "tvdb_id" not in info: continue
 			if "mal_id" not in info: continue
 			if "type" not in info: continue
-			if info["thetvdb_id"] != tvdb_id: continue
+			if info["tvdb_id"] != tvdb_id: continue
 			if info["type"] != "TV": continue
 
 			mal_ids.append(info["mal_id"])


### PR DESCRIPTION
# fix: rinominare thetvdb_id in tvdb_id

## Descrizione
Questa PR rinomina il parametro `thetvdb_id` in `tvdb_id` per allinearsi con la chiave utilizzata nel file JSON del database esterno (anime-list-full.json).