### PR TITLE
Feat: stagioni splittate

### DIFF
--- a/src/components/backend/connection/ExternalDB.py
+++ b/src/components/backend/connection/ExternalDB.py
@@ -123,7 +123,14 @@ class ExternalDB:
 		# Se non ho trovato nulla, provo con il titolo + numero stagione (es. "Fire Force 3")
 		if len(res) == 0 and season > 1:
 			self.log.info(f"Nessun risultato con '{title}', provo con '{title} {season}'")
-			res = self._search_with_variations(f"{title} {season}", mal_ids)
+			res = self._search_with_variations(f"{title} {season}", mal_ids)	
+		if 0 < len(res) < len(mal_ids) and season > 1:
+			found_ids = set(r["malId"] for r in res)
+			base = res[0]["name"].rsplit(' ', 1)[0] if res[0]["name"][-1].isdigit() else res[0]["name"]
+			if base != title:
+				self.log.info(f"Trovati {len(res)}/{len(mal_ids)}, provo con '{base} {season}'")
+				extra = self._search_with_variations(f"{base} {season}", mal_ids)
+				res.extend(r for r in extra if r["malId"] not in found_ids)
 
 		# Se non ho trovato nulla ritorno None
 		if len(res) == 0: return None

--- a/src/components/backend/connection/ExternalDB.py
+++ b/src/components/backend/connection/ExternalDB.py
@@ -1,4 +1,5 @@
 import httpx
+import re
 import animeworld as aw
 from typing import Optional
 
@@ -37,9 +38,57 @@ class ExternalDB:
 		"""
 		return list(self._data)
 	
-	def find(self, title:str, season:int, tvdb_id:int) -> Optional[dict[str, str]]:
+	def _generate_title_variations(self, title: str) -> list[str]:
 		"""
-		Cerca un url per il download.
+		Genera varianti del titolo per migliorare la ricerca su AnimeWorld.
+		
+		Args:
+		  title: titolo originale.
+		
+		Returns:
+		  Lista di varianti del titolo (senza duplicati).
+		"""
+		variations = [title]
+		
+		# Variante 1: rimuove spazi dopo i due punti (es. "Re: Zero" -> "Re:Zero")
+		no_space_after_colon = title.replace(": ", ":")
+		if no_space_after_colon != title:
+			variations.append(no_space_after_colon)
+		
+		# Variante 2: rimuove punteggiatura comune
+		no_punctuation = re.sub(r'[:,\.!]', '', title)
+		no_punctuation = re.sub(r'\s+', ' ', no_punctuation).strip()
+		if no_punctuation not in variations:
+			variations.append(no_punctuation)
+		
+		return variations
+	
+	def _search_with_variations(self, title: str, mal_ids: list[int]) -> list:
+		"""
+		Cerca su AnimeWorld provando diverse varianti del titolo.
+		
+		Args:
+		  title: titolo dell'anime.
+		  mal_ids: lista di MAL ID validi per il match.
+		
+		Returns:
+		  Lista di risultati filtrati, o lista vuota se non trova nulla.
+		"""
+		variations = self._generate_title_variations(title)
+		
+		for variant in variations:
+			res = aw.find(variant)
+			filtered = list(filter(lambda x: x["malId"] in mal_ids and x['language'] == 'jp', res))
+			if len(filtered) > 0:
+				if variant != title:
+					self.log.info(f"Trovato match con variante '{variant}' invece di '{title}'")
+				return filtered
+		
+		return []
+
+	def find(self, title:str, season:int, tvdb_id:int) -> Optional[list[dict[str, str]]]:
+		"""
+		Cerca gli url per il download di una stagione.
 
 		Args:
 		  title: titolo dell'anime.
@@ -47,28 +96,34 @@ class ExternalDB:
 		  tvdb_id: ID di thetvdb.
 		
 		Returns:
-		  Un dizionario con nome e url trovato.
+		  Una lista di dizionari con nome e url trovati (può contenere più elementi per split cour).
+		  None se non trova nulla.
 		"""
 
-		# Ottengo un elenco di ID di MyAnimeList che fanno match
+		# Ottengo un elenco di ID di MyAnimeList che fanno match per la stagione specifica
 		mal_ids = []
 		for info in self._data:
 			if "tvdb_id" not in info: continue
 			if "mal_id" not in info: continue
 			if "type" not in info: continue
+			if "season" not in info: continue
 			if info["tvdb_id"] != tvdb_id: continue
 			if info["type"] != "TV": continue
-
-			mal_ids.append(info["mal_id"])
+			
+			# Filtro per la stagione corretta (gestisce anche split cour)
+			if "tvdb" in info["season"] and info["season"]["tvdb"] == season:
+				mal_ids.append(info["mal_id"])
 		
 		# Se non ho trovato nulla ritorno None
 		if len(mal_ids) == 0: return None
 
-		# Ottengo tutti i risultati da animewolrd ricercando solamente con il nome dell'anime
-		res = aw.find(title)
+		# Cerco su AnimeWorld provando diverse varianti del titolo
+		res = self._search_with_variations(title, mal_ids)
 
-		# Filtro i risultati
-		res = list(filter(lambda x: x["malId"] in mal_ids and x['language'] == 'jp', res))
+		# Se non ho trovato nulla, provo con il titolo + numero stagione (es. "Fire Force 3")
+		if len(res) == 0 and season > 1:
+			self.log.info(f"Nessun risultato con '{title}', provo con '{title} {season}'")
+			res = self._search_with_variations(f"{title} {season}", mal_ids)
 
 		# Se non ho trovato nulla ritorno None
 		if len(res) == 0: return None
@@ -90,10 +145,11 @@ class ExternalDB:
 		# Riordino per data
 		res.sort(key=lambda x: (x["year"], x["season"]))
 
-		# Controllo se esiste la stagione
-		if len(res) < season: return None
-
-		return {
-			"name": res[season-1]["name"],
-			"url": res[season-1]["link"]
-		}
+		# Ritorno tutti i risultati (per split cour saranno entrambe le parti)
+		return [
+			{
+				"name": r["name"],
+				"url": r["link"]
+			}
+			for r in res
+		]

--- a/src/components/backend/core/Processor.py
+++ b/src/components/backend/core/Processor.py
@@ -260,12 +260,22 @@ class Processor:
 									self.log.debug(f"🔴 Ricerca automatica url per la stagione {season['number']} della serie '{elem['title']}': nessun risultato trovato.")
 									return False
 
-							self.log.warning(f"🟢 Ricerca automatica url per la stagione {season['number']} della serie '{elem['title']}': {res['url']}")
-							# aggiungo ciò che ho trovato
-							season["urls"].append(res["url"])
+							# res è una lista di dizionari con 'name' e 'url'
+							urls = [r["url"] for r in res]
+							names = [r["name"] for r in res]
+							
+							if len(urls) == 1:
+								self.log.warning(f"🟢 Ricerca automatica url per la stagione {season['number']} della serie '{elem['title']}': {urls[0]}")
+							else:
+								self.log.warning(f"🟢 Ricerca automatica url per la stagione {season['number']} della serie '{elem['title']}': trovati {len(urls)} url (split cour)")
+								for name, url in zip(names, urls):
+									self.log.warning(f"   - {name}: {url}")
+							
+							# aggiungo tutti gli url trovati
+							season["urls"].extend(urls)
 
-							# Adesso devo aggiornare la tabella, aggiungendo l'url
-							self.table.appendUrls(title, season['number'], [res["url"]])
+							# Adesso devo aggiornare la tabella, aggiungendo gli url
+							self.table.appendUrls(title, season['number'], urls)
 							return True
 
 		# Aggiungo gli url alle stagioni


### PR DESCRIPTION
# Feat: stagioni splittate
## Descrizione 
Questa PR inserisce il supporto alle stagioni splittate (es. Fire Force 3 parte 1 e Fire Force parte 2) che vengono trattate come un'unica stagione su Sonarr. Le due parti vengono filtrate per data per capire quale è la prima parte e poi scaricate in ordine.

Inoltre è stato aggiunto un sistema di normalizzazione automatica dei titoli per migliorare la ricerca su AnimeWorld. Il sistema ora prova automaticamente diverse varianti del titolo quando la ricerca fallisce:

- Rimozione spazi dopo i due punti (es. Re: Zero → Re:Zero)
- Rimozione della punteggiatura comune (:, ,, ., !)